### PR TITLE
feat: add tests using refined version of the prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ backend.tf.json
 **/*.bak
 **/*.*swp
 **/.DS_Store
+
+.cursor/

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -1,6 +1,3 @@
-# Tests for locals block logic in main.tf
-# Focus: User list-to-map transformation and role mapping
-
 mock_provider "datadog" {
   mock_data "datadog_role" {
     defaults = {
@@ -9,78 +6,6 @@ mock_provider "datadog" {
   }
 }
 
-# Test 1: User list-to-map transformation with single user
-run "test_single_user_transformation" {
-  command = plan
-
-  variables {
-    users = [
-      {
-        username             = "john.doe"
-        email                = "john.doe@example.com"
-        name                 = "John Doe"
-        roles                = ["standard"]
-        disabled             = false
-        send_user_invitation = true
-      }
-    ]
-  }
-
-  assert {
-    condition     = contains(keys(local.users), "john.doe")
-    error_message = "Map should be keyed by username 'john.doe'"
-  }
-
-  assert {
-    condition     = local.users["john.doe"].email == "john.doe@example.com"
-    error_message = "User email should be preserved in transformation"
-  }
-
-  assert {
-    condition     = local.users["john.doe"].name == "John Doe"
-    error_message = "User name should be preserved in transformation"
-  }
-}
-
-# Test 2: Role mapping logic
-run "test_role_mapping_logic" {
-  command = plan
-
-  variables {
-    users = [
-      {
-        username             = "admin.user"
-        email                = "admin@example.com"
-        name                 = "Admin User"
-        roles                = ["admin"]
-        disabled             = false
-        send_user_invitation = true
-      }
-    ]
-  }
-
-  assert {
-    condition     = local.roles["standard"] == "mock-role-id"
-    error_message = "Standard role should map to mock role ID"
-  }
-
-  assert {
-    condition     = local.roles["admin"] == "mock-role-id"
-    error_message = "Admin role should map to mock role ID"
-  }
-
-  assert {
-    condition     = local.roles["read_only"] == "mock-role-id"
-    error_message = "Read only role should map to mock role ID"
-  }
-
-  assert {
-    condition     = length(keys(local.roles)) == 3
-    error_message = "Should have exactly 3 role mappings"
-  }
-}
-
-# Test 3: Multiple users with mixed roles transformation
 run "test_multiple_users_mixed_roles" {
   command = plan
 

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -1,0 +1,151 @@
+# Tests for locals block logic in main.tf
+# Focus: User list-to-map transformation and role mapping
+
+mock_provider "datadog" {
+  mock_data "datadog_role" {
+    defaults = {
+      id = "mock-role-id"
+    }
+  }
+}
+
+# Test 1: User list-to-map transformation with single user
+run "test_single_user_transformation" {
+  command = plan
+
+  variables {
+    users = [
+      {
+        username             = "john.doe"
+        email                = "john.doe@example.com"
+        name                 = "John Doe"
+        roles                = ["standard"]
+        disabled             = false
+        send_user_invitation = true
+      }
+    ]
+  }
+
+  assert {
+    condition     = contains(keys(local.users), "john.doe")
+    error_message = "Map should be keyed by username 'john.doe'"
+  }
+
+  assert {
+    condition     = local.users["john.doe"].email == "john.doe@example.com"
+    error_message = "User email should be preserved in transformation"
+  }
+
+  assert {
+    condition     = local.users["john.doe"].name == "John Doe"
+    error_message = "User name should be preserved in transformation"
+  }
+}
+
+# Test 2: Role mapping logic
+run "test_role_mapping_logic" {
+  command = plan
+
+  variables {
+    users = [
+      {
+        username             = "admin.user"
+        email                = "admin@example.com"
+        name                 = "Admin User"
+        roles                = ["admin"]
+        disabled             = false
+        send_user_invitation = true
+      }
+    ]
+  }
+
+  assert {
+    condition     = local.roles["standard"] == "mock-role-id"
+    error_message = "Standard role should map to mock role ID"
+  }
+
+  assert {
+    condition     = local.roles["admin"] == "mock-role-id"
+    error_message = "Admin role should map to mock role ID"
+  }
+
+  assert {
+    condition     = local.roles["read_only"] == "mock-role-id"
+    error_message = "Read only role should map to mock role ID"
+  }
+
+  assert {
+    condition     = length(keys(local.roles)) == 3
+    error_message = "Should have exactly 3 role mappings"
+  }
+}
+
+# Test 3: Multiple users with mixed roles transformation
+run "test_multiple_users_mixed_roles" {
+  command = plan
+
+  variables {
+    users = [
+      {
+        username             = "alice.admin"
+        email                = "alice@example.com"
+        name                 = "Alice Admin"
+        roles                = ["admin", "standard"]
+        disabled             = false
+        send_user_invitation = true
+      },
+      {
+        username             = "bob.readonly"
+        email                = "bob@example.com"
+        name                 = "Bob ReadOnly"
+        roles                = ["read_only"]
+        disabled             = true
+        send_user_invitation = false
+      },
+      {
+        username             = "charlie.standard"
+        email                = "charlie@example.com"
+        name                 = "Charlie Standard"
+        roles                = ["standard"]
+        disabled             = false
+        send_user_invitation = true
+      }
+    ]
+  }
+
+  assert {
+    condition     = length(local.users) == 3
+    error_message = "Should transform three users into map with three entries"
+  }
+
+  assert {
+    condition     = (
+      contains(keys(local.users), "alice.admin")
+      && contains(keys(local.users), "bob.readonly")
+      && contains(keys(local.users), "charlie.standard")
+    )
+    error_message = "Map should contain all three usernames as keys"
+  }
+
+  assert {
+    condition     = (local.users["alice.admin"].disabled == false
+                    && local.users["bob.readonly"].disabled == true)
+    error_message = "User disabled status should be preserved in transformation"
+  }
+
+  assert {
+    condition     = (
+      contains(local.users["alice.admin"].roles, "admin")
+      && contains(local.users["alice.admin"].roles, "standard")
+    )
+    error_message = "Alice should have both admin and standard roles preserved"
+  }
+
+  assert {
+    condition     = (
+      length(local.users["bob.readonly"].roles) == 1
+      && contains(local.users["bob.readonly"].roles, "read_only")
+    )
+    error_message = "Bob should have only read_only role preserved"
+  }
+}

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -1,0 +1,182 @@
+# Tests for main.tf resource creation and configuration
+# Focus: datadog_user resource creation, attribute mapping, and for_each logic
+
+mock_provider "datadog" {
+  mock_data "datadog_role" {
+    defaults = { id = "mock-role-id" }
+  }
+  mock_resource "datadog_user" {
+    defaults = { id = "mock-user-id" }
+  }
+}
+
+# Test 1: Basic single user resource creation and attributes
+run "test_single_user_resource_creation" {
+  command = plan
+
+  variables {
+    users = [{
+      username = "john.doe", email = "john.doe@example.com", name = "John Doe"
+      roles = ["standard"], disabled = false, send_user_invitation = true
+    }]
+  }
+
+  assert {
+    condition = length(keys(datadog_user.users)) == 1
+    error_message = "Should create exactly one datadog_user resource"
+  }
+
+  assert {
+    condition = contains(keys(datadog_user.users), "john.doe")
+    error_message = "Resource key should match username 'john.doe'"
+  }
+
+  assert {
+    condition = datadog_user.users["john.doe"].email == "john.doe@example.com"
+    error_message = "User email should be correctly assigned to resource"
+  }
+
+  assert {
+    condition = datadog_user.users["john.doe"].name == "John Doe"
+    error_message = "User name should be correctly assigned to resource"
+  }
+
+  assert {
+    condition = datadog_user.users["john.doe"].disabled == false
+    error_message = "User disabled status should be correctly assigned"
+  }
+
+  assert {
+    condition = datadog_user.users["john.doe"].send_user_invitation == true
+    error_message = "User send_user_invitation should be correctly assigned"
+  }
+
+  assert {
+    condition = length(datadog_user.users["john.doe"].roles) == 1
+    error_message = "User should have exactly one role assigned"
+  }
+
+  assert {
+    condition = contains(datadog_user.users["john.doe"].roles, "mock-role-id")
+    error_message = "User role should be mapped to mock role ID"
+  }
+}
+
+# Test 2: Multiple users with comprehensive configuration testing
+run "test_multiple_users_comprehensive" {
+  command = plan
+
+  variables {
+    users = [
+      { username = "alice.admin", email = "alice@example.com", name = "Alice Admin",
+        roles = ["admin", "standard"], disabled = false, send_user_invitation = true },
+      { username = "bob.readonly", email = "bob@example.com", name = "Bob ReadOnly",
+        roles = ["read_only"], disabled = true, send_user_invitation = false },
+      { username = "user.with.dots", email = "user@example.com", name = "User With Dots",
+        roles = ["standard"], disabled = false, send_user_invitation = true },
+      { username = "user_with_underscores", email = "user2@example.com", name = "User With Underscores",
+        roles = ["admin"], disabled = false, send_user_invitation = true }
+    ]
+  }
+
+  # Resource count
+  assert {
+    condition = length(keys(datadog_user.users)) == 4
+    error_message = "Should create exactly four datadog_user resources"
+  }
+
+  # Key generation tests
+  assert {
+    condition = contains(keys(datadog_user.users), "alice.admin")
+    error_message = "Should create resource with key 'alice.admin'"
+  }
+
+  assert {
+    condition = contains(keys(datadog_user.users), "bob.readonly")
+    error_message = "Should create resource with key 'bob.readonly'"
+  }
+
+  assert {
+    condition = contains(keys(datadog_user.users), "user.with.dots")
+    error_message = "Should handle usernames with dots correctly"
+  }
+
+  assert {
+    condition = contains(keys(datadog_user.users), "user_with_underscores")
+    error_message = "Should handle usernames with underscores correctly"
+  }
+
+  # Disabled state tests
+  assert {
+    condition = datadog_user.users["alice.admin"].disabled == false
+    error_message = "Alice should be enabled"
+  }
+
+  assert {
+    condition = datadog_user.users["bob.readonly"].disabled == true
+    error_message = "Bob should be disabled"
+  }
+
+  # Invitation state tests
+  assert {
+    condition = datadog_user.users["alice.admin"].send_user_invitation == true
+    error_message = "Alice should send invitation"
+  }
+
+  assert {
+    condition = datadog_user.users["bob.readonly"].send_user_invitation == false
+    error_message = "Bob should not send invitation"
+  }
+
+  # Role count tests (accounting for set deduplication with mock)
+  assert {
+    condition = length(datadog_user.users["alice.admin"].roles) >= 1
+    error_message = "Alice should have at least one role assigned"
+  }
+
+  assert {
+    condition = length(datadog_user.users["bob.readonly"].roles) == 1
+    error_message = "Bob should have exactly one role assigned"
+  }
+
+  assert {
+    condition = length(datadog_user.users["user.with.dots"].roles) == 1
+    error_message = "User with dots should have exactly one role assigned"
+  }
+
+  assert {
+    condition = length(datadog_user.users["user_with_underscores"].roles) == 1
+    error_message = "User with underscores should have exactly one role assigned"
+  }
+
+  # Role mapping tests
+  assert {
+    condition = alltrue([
+      for role in datadog_user.users["alice.admin"].roles : role == "mock-role-id"
+    ])
+    error_message = "All of Alice's roles should be mapped to mock role IDs"
+  }
+
+  assert {
+    condition = alltrue([
+      for role in datadog_user.users["bob.readonly"].roles : role == "mock-role-id"
+    ])
+    error_message = "All of Bob's roles should be mapped to mock role IDs"
+  }
+
+  # Email and name preservation tests
+  assert {
+    condition = datadog_user.users["bob.readonly"].name == "Bob ReadOnly"
+    error_message = "Bob should have correct name assigned"
+  }
+
+  assert {
+    condition = datadog_user.users["user.with.dots"].email == "user@example.com"
+    error_message = "User with dots should have correct email assigned"
+  }
+
+  assert {
+    condition = datadog_user.users["user_with_underscores"].email == "user2@example.com"
+    error_message = "User with underscores should have correct email assigned"
+  }
+}

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -10,173 +10,64 @@ mock_provider "datadog" {
   }
 }
 
-# Test 1: Basic single user resource creation and attributes
-run "test_single_user_resource_creation" {
-  command = plan
-
-  variables {
-    users = [{
-      username = "john.doe", email = "john.doe@example.com", name = "John Doe"
-      roles = ["standard"], disabled = false, send_user_invitation = true
-    }]
-  }
-
-  assert {
-    condition = length(keys(datadog_user.users)) == 1
-    error_message = "Should create exactly one datadog_user resource"
-  }
-
-  assert {
-    condition = contains(keys(datadog_user.users), "john.doe")
-    error_message = "Resource key should match username 'john.doe'"
-  }
-
-  assert {
-    condition = datadog_user.users["john.doe"].email == "john.doe@example.com"
-    error_message = "User email should be correctly assigned to resource"
-  }
-
-  assert {
-    condition = datadog_user.users["john.doe"].name == "John Doe"
-    error_message = "User name should be correctly assigned to resource"
-  }
-
-  assert {
-    condition = datadog_user.users["john.doe"].disabled == false
-    error_message = "User disabled status should be correctly assigned"
-  }
-
-  assert {
-    condition = datadog_user.users["john.doe"].send_user_invitation == true
-    error_message = "User send_user_invitation should be correctly assigned"
-  }
-
-  assert {
-    condition = length(datadog_user.users["john.doe"].roles) == 1
-    error_message = "User should have exactly one role assigned"
-  }
-
-  assert {
-    condition = contains(datadog_user.users["john.doe"].roles, "mock-role-id")
-    error_message = "User role should be mapped to mock role ID"
-  }
-}
-
-# Test 2: Multiple users with comprehensive configuration testing
+# Test: Multiple users with comprehensive configuration testing
 run "test_multiple_users_comprehensive" {
   command = plan
 
   variables {
     users = [
       { username = "alice.admin", email = "alice@example.com", name = "Alice Admin",
-        roles = ["admin", "standard"], disabled = false, send_user_invitation = true },
+      roles = ["admin", "standard"], disabled = false, send_user_invitation = true },
       { username = "bob.readonly", email = "bob@example.com", name = "Bob ReadOnly",
-        roles = ["read_only"], disabled = true, send_user_invitation = false },
+      roles = ["read_only"], disabled = true, send_user_invitation = false },
       { username = "user.with.dots", email = "user@example.com", name = "User With Dots",
-        roles = ["standard"], disabled = false, send_user_invitation = true },
+      roles = ["standard"], disabled = false, send_user_invitation = true },
       { username = "user_with_underscores", email = "user2@example.com", name = "User With Underscores",
-        roles = ["admin"], disabled = false, send_user_invitation = true }
+      roles = ["admin"], disabled = false, send_user_invitation = true }
     ]
   }
 
-  # Resource count
+  # Validate resource creation and key generation
   assert {
-    condition = length(keys(datadog_user.users)) == 4
+    condition     = length(keys(datadog_user.users)) == 4
     error_message = "Should create exactly four datadog_user resources"
   }
 
-  # Key generation tests
-  assert {
-    condition = contains(keys(datadog_user.users), "alice.admin")
-    error_message = "Should create resource with key 'alice.admin'"
-  }
-
-  assert {
-    condition = contains(keys(datadog_user.users), "bob.readonly")
-    error_message = "Should create resource with key 'bob.readonly'"
-  }
-
-  assert {
-    condition = contains(keys(datadog_user.users), "user.with.dots")
-    error_message = "Should handle usernames with dots correctly"
-  }
-
-  assert {
-    condition = contains(keys(datadog_user.users), "user_with_underscores")
-    error_message = "Should handle usernames with underscores correctly"
-  }
-
-  # Disabled state tests
-  assert {
-    condition = datadog_user.users["alice.admin"].disabled == false
-    error_message = "Alice should be enabled"
-  }
-
-  assert {
-    condition = datadog_user.users["bob.readonly"].disabled == true
-    error_message = "Bob should be disabled"
-  }
-
-  # Invitation state tests
-  assert {
-    condition = datadog_user.users["alice.admin"].send_user_invitation == true
-    error_message = "Alice should send invitation"
-  }
-
-  assert {
-    condition = datadog_user.users["bob.readonly"].send_user_invitation == false
-    error_message = "Bob should not send invitation"
-  }
-
-  # Role count tests (accounting for set deduplication with mock)
-  assert {
-    condition = length(datadog_user.users["alice.admin"].roles) >= 1
-    error_message = "Alice should have at least one role assigned"
-  }
-
-  assert {
-    condition = length(datadog_user.users["bob.readonly"].roles) == 1
-    error_message = "Bob should have exactly one role assigned"
-  }
-
-  assert {
-    condition = length(datadog_user.users["user.with.dots"].roles) == 1
-    error_message = "User with dots should have exactly one role assigned"
-  }
-
-  assert {
-    condition = length(datadog_user.users["user_with_underscores"].roles) == 1
-    error_message = "User with underscores should have exactly one role assigned"
-  }
-
-  # Role mapping tests
   assert {
     condition = alltrue([
-      for role in datadog_user.users["alice.admin"].roles : role == "mock-role-id"
+      for username in ["alice.admin", "bob.readonly", "user.with.dots", "user_with_underscores"] :
+      contains(keys(datadog_user.users), username)
     ])
-    error_message = "All of Alice's roles should be mapped to mock role IDs"
+    error_message = "Should handle all username formats (dots, underscores) as resource keys"
   }
 
+  # Validate attribute preservation for specific test cases
+  assert {
+    condition = (
+      datadog_user.users["alice.admin"].disabled == false &&
+      datadog_user.users["bob.readonly"].disabled == true &&
+      datadog_user.users["alice.admin"].send_user_invitation == true &&
+      datadog_user.users["bob.readonly"].send_user_invitation == false
+    )
+    error_message = "User attributes (disabled, send_user_invitation) should be preserved correctly"
+  }
+
+  # Validate role mapping and mock behavior
   assert {
     condition = alltrue([
-      for role in datadog_user.users["bob.readonly"].roles : role == "mock-role-id"
+      for user_key, user in datadog_user.users :
+      alltrue([for role in user.roles : role == "mock-role-id"])
     ])
-    error_message = "All of Bob's roles should be mapped to mock role IDs"
+    error_message = "All user roles should be mapped to mock role IDs"
   }
 
-  # Email and name preservation tests
+  # Validate email and name preservation for edge cases
   assert {
-    condition = datadog_user.users["bob.readonly"].name == "Bob ReadOnly"
-    error_message = "Bob should have correct name assigned"
-  }
-
-  assert {
-    condition = datadog_user.users["user.with.dots"].email == "user@example.com"
-    error_message = "User with dots should have correct email assigned"
-  }
-
-  assert {
-    condition = datadog_user.users["user_with_underscores"].email == "user2@example.com"
-    error_message = "User with underscores should have correct email assigned"
+    condition = (
+      datadog_user.users["user.with.dots"].email == "user@example.com" &&
+      datadog_user.users["user_with_underscores"].email == "user2@example.com" &&
+      datadog_user.users["bob.readonly"].name == "Bob ReadOnly"
+    )
+    error_message = "Email and name attributes should be preserved for all username formats"
   }
 }


### PR DESCRIPTION
## what
- use v2 of the tf tests child module prompt, https://github.com/masterpointio/internal-prompts/pull/13
- focus on main.tf and locals logic.