### PR TITLE
chore: sync with latest template state

### DIFF
--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run Trunk Upgrade
-        uses: masterpointio/github-action-trunk-upgrade@feat/inital-version
+        uses: masterpointio/github-action-trunk-upgrade@v0.1.0
         with:
           app-id: ${{ secrets.MP_BOT_APP_ID }}
           app-private-key: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ backend.tf.json
 
 # Other
 **/*.backup
-***/*.tmp
+**/*.tmp
 **/*.temp
 **/*.bak
 **/*.*swp


### PR DESCRIPTION
This PR syncs the repository with the latest state from 'terraform-module-template'.

**Template Version:**
- **Tag:** v0.8.1
- **Commit SHA:** 9ef513a
- **Repository:** https://github.com/masterpointio/terraform-module-template

**Changes include:**
- Updated configuration files (.checkov.yaml, .markdownlint.yaml, etc.)
- Updated GitHub workflows and templates
- Updated linting and formatting configurations
- Updated documentation templates