### PR TITLE
feat!: drop lifecycle ignore_changes=[name] and require datadog provider >= 4.0

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = "~> 3.14"
+      version = ">= 4.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -14,10 +14,4 @@ resource "datadog_user" "users" {
   name                 = each.value.name
   roles                = [for role in each.value.roles : local.roles[role]]
   send_user_invitation = each.value.send_user_invitation
-
-  # Avoids unnecessary resource recreation/drift when users alter their names.
-  # Such changes are non-critical and can be safely ignored by Terraform.
-  lifecycle {
-    ignore_changes = [name]
-  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.14"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Removes the `lifecycle { ignore_changes = [name] }` workaround on `datadog_user.users`. It's no longer needed: [DataDog/terraform-provider-datadog#2784](https://github.com/DataDog/terraform-provider-datadog/pull/2784) (shipped in v3.55, Feb 2025) made the `name` field `Optional + Computed`, so when the identity provider (Google/SAML) overrides the user's name, Terraform no longer reports drift.
- Bumps the required Datadog provider to `>= 4.0` to guarantee the fix is present and to opt into the v4 provider series. v4.0's [breaking changes](https://github.com/DataDog/terraform-provider-datadog/blob/master/docs/guides/v4-upgrade-guide.md) do not touch `datadog_user` or `datadog_role`.
- Bumps the constraint in `examples/complete/versions.tf` so the example stays in sync with the module.

## Why

The `lifecycle` block was a workaround for a known drift loop with Google/SAML-managed users — the IdP overwrites the user's display name and Terraform kept trying to revert it. Per the upstream PR description: *"if you use Google auth, it is recommended to not set optional `name` parameter"*. With `name` now Optional + Computed in the provider schema, the workaround is dead code and the constraint should reflect the version that contains the fix.

## Test plan

- [x] `tofu test` — both `tests/locals.tftest.hcl` and `tests/main.tftest.hcl` pass against the updated module
- [x] Reviewer: confirm `>= 4.0` is the desired floor (alternative: `>= 3.55` if the maintainers want to keep v3 consumers supported)

VALIDATED THIS IN OUR INTERNAL DATADOG USAGE https://github.com/masterpointio/mp-infra/pull/421